### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,33 +3,22 @@
 [![GitHub version](https://badge.fury.io/gh/AppScale%2Fappscale.svg)](http://badge.fury.io/gh/AppScale%2Fappscale)
 [![AppScale license](https://img.shields.io/badge/license-Apache%202-blue.svg)](https://github.com/AppScale/appscale/blob/master/LICENSE)
 
-AppScale is an easy-to-manage serverless platform for building and running scalable web and mobile applications on any infrastructure. 
+AppScale GTS is an open source serverless platform for building and running scalable web and mobile applications on any infrastructure. 
 
 The platform enables developers to focus solely on business logic in order to rapidly build scalable apps, cleanly separating it from deployment and scaling logic. It allows operations to provide a consistent, tunable environment that can simplify running and maintaining apps on multiple infrastructures. The business will benefit from faster time-to-market, reduced operational costs, maximized application lifetime, and the flexibility to integrate with new or existing technologies.
 
-AppScale is open source and modeled on Google App Engine APIs, allowing developers to automatically deploy and scale unmodified Google App Engine applications over public and private cloud systems and on-premise clusters. It currently supports Python, Go, PHP and Java applications. The software is developed and maintained by AppScale Systems, Inc., based in Santa Barbara, California, and Google.
+AppScale GTS is open source and modeled on Google App Engine APIs, allowing developers to automatically deploy and scale unmodified Google App Engine applications over public and private cloud systems and on-premise clusters. It currently supports Python, Go, PHP and Java applications. The software was developed by AppScale Systems, Inc., based in Santa Barbara, California, and Google. In 2019, the company ended commercial support AppScale GTS, however the source code remains available in this GitHub Repo. 
 
-
-## Why Use AppScale?
-The goal of AppScale is to provide developers with a rapid, API-driven development platform that can run applications on any cloud infrastructure. AppScale decouples application logic from its service ecosystem to give developers and cloud administrators control over application deployment, data storage, resource use, backup, and migration.
-
+## Why Use AppScale GTS?
+The goal of AppScale GTS is to provide developers with a rapid, API-driven development platform that can run applications on any cloud infrastructure. AppScale GTS decouples application logic from its service ecosystem to give developers and cloud administrators control over application deployment, data storage, resource use, backup, and migration.
 
 ## I Want ...
 * to [contribute](https://github.com/AppScale/appscale/wiki/Contribute%21)
-* to [try AppScale](https://www.appscale.com/get-started/)
-* to see [how other people use AppScale](https://www.appscale.com/why-appscale/)
-* [customer support](https://www.appscale.com/products/appscale-customer-success/)
 * to [learn more](https://github.com/AppScale/appscale/wiki)
 
-
 ## Documentation
-* Getting Started
-  * [AppScale FastStart](https://www.appscale.com/get-started/)
-  * [Deployment types](https://www.appscale.com/get-started/deployment-types/)
-  * [Deploy AppScale](https://www.appscale.com/get-started/deploy-appscale/)
 * Users
-  * [Managing Apps and AppScale](https://www.appscale.com/get-started/management/)
-  * [Automated Data Persistence](https://github.com/AppScale/appscale/wiki/Automated-Data-Persistence)
+   * [Automated Data Persistence](https://github.com/AppScale/appscale/wiki/Automated-Data-Persistence)
   * [Multinode Deployments](https://github.com/AppScale/appscale/wiki/Distributed-Deployment)
   * [Making AppScale Scale](https://github.com/AppScale/appscale/wiki#making-appscale-scale)
 * Developers
@@ -41,5 +30,3 @@ The goal of AppScale is to provide developers with a rapid, API-driven developme
 
 ## Community and Support
 Join the [Community Google Group](http://groups.google.com/group/appscale_community) for announcements, help, and to discuss cloud research.
-
-Also, join us on [#appscale on freenode](http://webchat.freenode.net/?channels=appscale&uio=d4) if you have questions, suggestions, comments, or just want to say hi!


### PR DESCRIPTION
- Changed AppScale to AppScale GTS
- Added clarification that AppScale GTS is not supported anymore however source code remains available in GitHub Repo 
- Deleted all links to >appscale.com< domain and only left links to GitHub Wiki and Google Group